### PR TITLE
Don't attempt to transform null, because it's an object (not really)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ class NMI {
       return obj;
     }
 
-    if(typeof obj === 'object') {
+    if(obj !== null && typeof obj === 'object') {
       Object.keys(obj).forEach((key) => {
         if(key === 'merchantDefinedField') {
           let mdf = obj[key];


### PR DESCRIPTION
Because JavaScript contains a certain amount of legacy stupid, typeof null === 'object'. See http://2ality.com/2013/10/typeof-null.html.